### PR TITLE
Export generateFormData function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   getValidatedFormData,
   validateFormData,
   getFormDataFromSearchParams,
+  generateFormData,
 } from "./utilities";
 export * from "./hook";
 export type { UseRemixFormOptions } from "./hook";


### PR DESCRIPTION
# Description

This change exports the `generateFormData` function.

When implementing optimistic ui via `useFetcher`, we need to get the parsed data from `fetcher.formData`. We cannot use `parseFormData` because it returns a promise but it's possible if we use the `generateFormData` function which is not async.

```tsx
const fetcher = useFetcher();

// This should have the correct json data for optimistic ui
const pendingItems = fetcher.formData ? generateFormData(fetcher.formData) : null

```

This should also partially resolve this discussion: https://github.com/Code-Forge-Net/remix-hook-form/discussions/24

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Testing in local and I was able to import `generateFormData`

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules