### PR TITLE
Make event on handleSubmit function optional to match react-hook-form

### DIFF
--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -18,19 +18,19 @@ import {
   type SubmitErrorHandler,
   type SubmitHandler,
   useFormContext,
+  useForm,
+  FormProvider,
+  type DefaultValues,
+  type FieldValues,
+  type FormState,
+  type KeepStateOptions,
+  type Path,
+  type RegisterOptions,
+  type UseFormHandleSubmit,
+  type UseFormProps,
+  type UseFormReturn,
 } from "react-hook-form";
-import { useForm, FormProvider } from "react-hook-form";
-import type {
-  DefaultValues,
-  FieldValues,
-  FormState,
-  KeepStateOptions,
-  Path,
-  RegisterOptions,
-  UseFormHandleSubmit,
-  UseFormProps,
-  UseFormReturn,
-} from "react-hook-form";
+
 import { createFormData } from "../utilities";
 
 export type SubmitFunctionOptions = Parameters<SubmitFunction>[1];
@@ -189,7 +189,7 @@ export const useRemixForm = <T extends FieldValues>({
   );
 
   const handleSubmit = useMemo(
-    () => (e: FormEvent<HTMLFormElement>) => {
+    () => (e?: FormEvent<HTMLFormElement>) => {
       const encType = e?.currentTarget?.enctype as FormEncType | undefined;
       const method = e?.currentTarget?.method as FormMethod | undefined;
       const onValidHandler = submitHandlers?.onValid ?? onSubmit;


### PR DESCRIPTION
# Description

This PR makes the `event` on the `handleSubmit` option to match the `react-hook-form` interface.

Fixes #106 




## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules