### PR TITLE
Improve defaultValue prop resolution

### DIFF
--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -20,6 +20,7 @@ import {
   useFormContext,
   useForm,
   FormProvider,
+  get,
   type DefaultValues,
   type FieldValues,
   type FormState,
@@ -182,10 +183,13 @@ export const useRemixForm = <T extends FieldValues>({
       ) => ({
         ...methods.register(name, options),
         ...(!options?.disableProgressiveEnhancement && {
-          defaultValue: data?.defaultValues?.[name] ?? "",
+          defaultValue:
+            get(data?.defaultValues, name) ??
+            get(methods.formState.defaultValues, name) ??
+            "",
         }),
       }),
-    [methods.register, data?.defaultValues],
+    [methods.register, data?.defaultValues, methods.formState],
   );
 
   const handleSubmit = useMemo(


### PR DESCRIPTION
# Description

`remix-hook-form` currently returns a `defaultValue` prop from the `register` function, based on values returned from `useActionData`. This is done to enable progressive enhancement.

This PR modifies this feature in two ways:
1. Adds support for nested paths by using the `get` utility from `react-hook-form`
2. Avoids empty fields flashing on first visit by respecting the `defaultValues` parameter

First one is pretty straightforward.

The second one needs a bit of an explanation. I often use the following pattern for "edit existing entity" forms:

```typescript
const { existingEntity } = useLoaderData();
const actionData = useActionData();

const actionDataValues = actionData?.defaultValues;
const defaultValues = actionDataValues || existingEntity;

const { handleSubmit, register } = useRemixForm({ mode: 'onSubmit', defaultValues });
```

This works fine, but since `react-hook-form` does not return the `defaultValue` prop form its `register` function, the HTML output from the server contains no default values, and there is a flash of empty fields before RHF kicks in and fills them out.
The workaround is to specify the `defaultValue` in JSX yourself, but this is a bit repetitive:
```typescript
<input type="text" {...register("street")} defaultValue={defaultValues?.street} />
```

The RHF team said in [8707](https://github.com/react-hook-form/react-hook-form/issues/8707) that providing default values during SSR is unlikely to be implemented in RHF itself (see also [this discussion](https://github.com/orgs/react-hook-form/discussions/10603)).
Considering that `remix-hook-form` package is aimed to support progressive enhancement and already provides `defaultValue`, I think its useful to implement this in the package.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Unit tests
- [X] Manual tests in the browser

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules