### PR TITLE
feat: add action support from Form config

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,10 @@ If you're using a GET request formData is not available on the request so you ca
 - `submitHandlers`: an object containing two properties:
   - `onValid`: can be passed into the function to override the default behavior of the `handleSubmit` success case provided by the hook.
   - `onInvalid`: can be passed into the function to override the default behavior of the `handleSubmit` error case provided by the hook.
-- `submitConfig`: allows you to pass additional configuration to the `useSubmit` function from Remix, such as `{ replace: true }` to replace the current history entry instead of pushing a new one. The `submitConfig` trumps `Form` props from Remix. But the `Form` props are used if no submitConfig is provided.
+- `submitConfig`: allows you to pass additional configuration to the `useSubmit` function from Remix, such as `{ replace: true }` to replace the current history entry instead of pushing a new one. The `submitConfig` trumps `Form` props from Remix. The following props will be used from `Form` if no submitConfig is provided:
+  - `method`
+  - `action`
+  - `encType`
 - `submitData`: allows you to pass additional data to the backend when the form is submitted.
 - `fetcher`: if provided then this fetcher will be used to submit data and get a response (errors / defaultValues) instead of Remix's `useSubmit` and `useActionData` hooks.
 

--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -101,15 +101,7 @@ export const useRemixForm = <T extends FieldValues>({
         setIsSubmittedSuccessfully(true);
         const encType = submitConfig?.encType ?? formEncType;
         const method = submitConfig?.method ?? formMethod ?? "post";
-
-        let action = submitConfig?.action;
-        if (!action && formAction) {
-          const formActionUrl = new URL(formAction, window.location.origin);
-          action = formActionUrl.origin === window.location.origin
-            ? `${formActionUrl.pathname}${formActionUrl.search}`
-            : formActionUrl.href;
-        }
-
+        const action = submitConfig?.action ?? formAction;
         const submitPayload = { ...data, ...submitData };
         const formData =
           encType === "application/json"


### PR DESCRIPTION
# Description

This PR allows the `action` prop to be passed from `Form` to the submit configuration.

Given the action prop will be an absolute URL, I added the following options:

- If the URL is relative, it'll be passed as it is.
- If the URL is absolute and `origin is the same as window.location.origin`, then the origin will be stripped to get a relative URL.
- If the URL is absolute and `origin is different than window.location.origin`, i.e. an external URL, then it'll be passed as it is.

Relates to #80 


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have tested this manually. There doesn't seem to be a test suite for this sort of changes (although happy to keep contributing to add one).

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules